### PR TITLE
[TOREVIEW] Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,13 @@
           <target>11</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.0</version>
+        <configuration>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Implémente #45 

Un site Javadoc est créé dans `target/site` à l'aide de la commande `mvn javadoc:javadoc`